### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/platforms/android/src/org/apache/cordova/camera/FileHelper.java
+++ b/platforms/android/src/org/apache/cordova/camera/FileHelper.java
@@ -151,6 +151,9 @@ public class FileHelper {
             int column_index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
             cursor.moveToFirst();
             result = cursor.getString(column_index);
+			if (cursor != null) {
+				cursor.close();
+			}
 
         } catch (Exception e) {
             result = null;


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis