### PR TITLE
Fix typo in exportGPXs

### DIFF
--- a/platforms/android/assets/www/templates/settings.html
+++ b/platforms/android/assets/www/templates/settings.html
@@ -188,7 +188,7 @@
 
 <div class="content double-padding">
     <h4 class="positive">{{ "_backup_and_restore" | translate }}</h4>
-  <button ng-click="exportAsGPX(true)" class="button icon-left ion-pin button-positive button-block">{{ "_export_as_gpx" | translate }}</button>
+  <button ng-click="exportGPXs(true)" class="button icon-left ion-pin button-positive button-block">{{ "_export_as_gpx" | translate }}</button>
   <!--<button ng-if="platform === 'Android'" onclick="document.getElementById('gpxFile').click();" class="button icon-left ion-pin button-positive button-block">{{ "_import_gpxs" | translate }}-->
  <!--</button>-->
   <!--<button ng-if="platform === 'iOS'" onclick="iosFilePicker();"

--- a/platforms/ios/ForRunners.xcarchive/Products/Applications/ForRunners.app/www/templates/settings.html
+++ b/platforms/ios/ForRunners.xcarchive/Products/Applications/ForRunners.app/www/templates/settings.html
@@ -188,7 +188,7 @@
 
 <div class="content double-padding">
     <h4 class="positive">{{ "_backup_and_restore" | translate }}</h4>
-  <button ng-click="exportAsGPX(true)" class="button icon-left ion-pin button-positive button-block">{{ "_export_as_gpx" | translate }}</button>
+  <button ng-click="exportGPXs(true)" class="button icon-left ion-pin button-positive button-block">{{ "_export_as_gpx" | translate }}</button>
   <!--<button ng-if="platform === 'Android'" onclick="document.getElementById('gpxFile').click();" class="button icon-left ion-pin button-positive button-block">{{ "_import_gpxs" | translate }}-->
  <!--</button>-->
   <!--<button ng-if="platform === 'iOS'" onclick="iosFilePicker();"

--- a/platforms/ios/www/templates/settings.html
+++ b/platforms/ios/www/templates/settings.html
@@ -188,7 +188,7 @@
 
 <div class="content double-padding">
     <h4 class="positive">{{ "_backup_and_restore" | translate }}</h4>
-  <button ng-click="exportAsGPX(true)" class="button icon-left ion-pin button-positive button-block">{{ "_export_as_gpx" | translate }}</button>
+  <button ng-click="exportGPXs(true)" class="button icon-left ion-pin button-positive button-block">{{ "_export_as_gpx" | translate }}</button>
   <!--<button ng-if="platform === 'Android'" onclick="document.getElementById('gpxFile').click();" class="button icon-left ion-pin button-positive button-block">{{ "_import_gpxs" | translate }}-->
  <!--</button>-->
   <!--<button ng-if="platform === 'iOS'" onclick="iosFilePicker();"

--- a/www/templates/settings.html
+++ b/www/templates/settings.html
@@ -188,7 +188,7 @@
 
 <div class="content double-padding">
     <h4 class="positive">{{ "_backup_and_restore" | translate }}</h4>
-  <button ng-click="exportAsGPX(true)" class="button icon-left ion-pin button-positive button-block">{{ "_export_as_gpx" | translate }}</button>
+  <button ng-click="exportGPXs(true)" class="button icon-left ion-pin button-positive button-block">{{ "_export_as_gpx" | translate }}</button>
   <!--<button ng-if="platform === 'Android'" onclick="document.getElementById('gpxFile').click();" class="button icon-left ion-pin button-positive button-block">{{ "_import_gpxs" | translate }}-->
  <!--</button>-->
   <!--<button ng-if="platform === 'iOS'" onclick="iosFilePicker();"


### PR DESCRIPTION
It seems that the method `exportAsGPX` was renamed to `exportGPXs` but not
everywhere.